### PR TITLE
Modify schedule class to create schedule objects

### DIFF
--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
@@ -283,12 +283,14 @@ public class RouteController {
   public ResponseEntity<?> deleteResourceType(@RequestParam(value = "typeName") String typeName) {
     try {
       List<Task> tasks = LiveSchedApplication.myFileDatabase.getAllTasks();
-      List<ResourceType> resourceTypeList = LiveSchedApplication.myFileDatabase.getAllResourceTypes();
+      List<ResourceType> resourceTypeList =
+          LiveSchedApplication.myFileDatabase.getAllResourceTypes();
       for (ResourceType resourceType : resourceTypeList) {
         if (resourceType.getTypeName().equals(typeName)) {
           for (Task task : tasks) {
             if (task.getResources().containsKey(resourceType)) {
-              return new ResponseEntity<>("Cannot delete a resourceType currently in use", HttpStatus.BAD_REQUEST);
+              return new ResponseEntity<>("Cannot delete a resourceType currently in use",
+                  HttpStatus.BAD_REQUEST);
             }
           }
           LiveSchedApplication.myFileDatabase.deleteResourceType(resourceType);

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/Schedule.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/Schedule.java
@@ -1,95 +1,122 @@
 package dev.coms4156.project.livesched;
 
+import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Queue;
 
 /**
- * Coordinates scheduling given a Task and a List of ResourceTypes.
- * This class stores the available ResourceTypes and a Task
- * and modifies their values upon scheduling
+ * Coordinates scheduling given a list of tasks.
+ * This class creates a schedule that pairs tasks with resourceTypes and
+ * updates their values accordingly
  */
 public class Schedule {
   private final String scheduleId;
   private Queue<Task> tasks;
-  private List<ResourceType> resourceTypes;
   private double maxDistance;
+  private Map<Task, List<Resource>> taskSchedule = new LinkedHashMap<>();
 
   /**
    * Constructs a new Schedule object with the given parameters.
    *
    * @param scheduleId        the unique ID of the schedule
-   * @param resourceTypes     list of all resource types
-   * @param maxDistance       maxinmum distance from task to resource
+   * @param tasks             list of all tasks
+   * @param maxDistance       maximum distance from task to resource
    * @throws IllegalArgumentException if scheduleId is null or empty, resourceTypes is null,
    *                                  or maxDistance is negative
    */
-  public Schedule(String scheduleId, List<ResourceType> resourceTypes, double maxDistance) {
+  public Schedule(String scheduleId, List<Task> tasks, double maxDistance) {
     if (scheduleId == null || scheduleId.trim().isEmpty()) {
       throw new IllegalArgumentException("Schedule ID cannot be null or empty.");
     }
-    if (resourceTypes == null) {
-      throw new IllegalArgumentException("Resource types list cannot be null.");
+    if (tasks == null) {
+      throw new IllegalArgumentException("Tasks list cannot be null.");
     }
     if (maxDistance < 0) {
       throw new IllegalArgumentException("Maximum distance cannot be negative.");
     }
     this.scheduleId = scheduleId;
-    this.resourceTypes = resourceTypes;
     this.maxDistance = maxDistance;
 
     Comparator<Task> comparator = new TaskComparator();
     this.tasks = new PriorityQueue<Task>(comparator);  // queue of tasks in order of priority
+    this.tasks.addAll(tasks);
   }
 
   /**
-   * Given a maximum distance range from the location of a Task,
-   * returns a list of all available ResourceTypes nearby, if exists.
+   * Creates a schedule by assigning available resources to tasks based
+   * on their requirements and start times.
    *
-   * @param task  high priority task that needs to be matched with a resource type
-   * @return first ResourceType matched; otherwise, null.
-   * @throws IllegalArgumentException if task is null
+   * @return a {@code Map<Task, List<Resource>>} where each schedulable task is mapped to
+   *     the list of resources assigned to it,
+   *     or an empty map if no tasks could be scheduled.
+   *
    */
+  public Map<Task, List<Resource>> createSchedule() {
+    for (Task task : tasks) {
+      // Store assigned resources for this task
+      List<Resource> assignedResources = new ArrayList<>();
+      // Track whether we can schedule this task
+      boolean canSchedule = true;
 
-  public ResourceType matchTaskWithResource(Task task) {
-    if (task == null) {
-      throw new IllegalArgumentException("Task cannot be null.");
-    }
+      // Iterate over the required resource types for the task
+      for (Map.Entry<ResourceType, Integer> entry : task.getResources().entrySet()) {
+        ResourceType resourceType = entry.getKey();
+        int requiredUnits = entry.getValue();
 
-    Map<ResourceType, Integer> resourceNeeded = task.getResources();
-    Location taskLoc = task.getLocation();
-    for (ResourceType resourceType : resourceTypes) {
-      Location resourceLoc = resourceType.getLocation();
-      double distance = taskLoc.getDistance(resourceLoc);
-      if (distance <= maxDistance
-          && resourceNeeded.containsKey(resourceType)
-          && resourceType.findAvailableResource(task.getStartTime()) != null
-          && resourceNeeded.get(resourceType) <= resourceType.getTotalUnits()) {
-        return resourceType;
+        if (requiredUnits > resourceType.countAvailableUnits(task.getStartTime())) {
+          canSchedule = false;
+          break;
+        }
+
+        List<Resource> availableResources = new ArrayList<>();
+
+        for (int i = 0; i < requiredUnits; i++) {
+          Resource resource = resourceType.findAvailableResource(task.getStartTime());
+          if (resource != null
+              && resourceType.getLocation().getDistance(task.getLocation()) <= maxDistance) {
+            availableResources.add(resource);
+            resource.assignUntil(task.getEndTime());
+          } else {
+            canSchedule = false;
+            break;
+          }
+        }
+        if (!canSchedule) {
+          for (Resource resource : availableResources) {
+            resource.release();  // Free up the resources since task cannot be scheduled right now
+          }
+          break;
+        }
+        assignedResources.addAll(availableResources);
+      }
+      // all resourceTypes available in required quantities
+      if (canSchedule) {
+        taskSchedule.put(task, assignedResources);
       }
     }
-    return null;
+    return taskSchedule;
   }
 
-  //  public List<ResourceType> matchTaskWithResource(Task task) {
-  //    List<ResourceType> result = new ArrayList<>();
-  //    Map<ResourceType, Integer> resourceNeeded = task.getResources();
-  //    Location taskLoc = task.getLocation();
-  //    for (ResourceType resourceType : resourceTypes) {
-  //      Location resourceLoc = resourceType.getLocation();
-  //      double distance = taskLoc.getDistance(resourceLoc);
-  //      if (distance <= maxDistance && resourceNeeded.containsKey(resourceType)) {
-  //        if (resourceType.findAvailableResource(task.getStartTime()) != null
-  //                && resourceNeeded.get(resourceType) <= resourceType.getTotalUnits()) {
-  //          result.add(resourceType);
-  //        }
-  //      }
-  //    }
-  //    return result;
-  //  }
+  /**
+   * Completes a task by removing it from allTasks and taskSchedule.
+   */
+  public void completeTask(Task task) {
+    if (!tasks.contains(task)) {
+      throw new IllegalArgumentException("Task not found in the tasks list.");
+    }
+    if (taskSchedule.containsKey(task)) {
+      List<Resource> assignedResources = taskSchedule.get(task);
+      for (Resource resource : assignedResources) {
+        resource.release();
+      }
+      taskSchedule.remove(task);
+    }
+    tasks.remove(task);
+  }
 
   /**
    * Receives task from network by adding given task to a priority queue.
@@ -102,38 +129,6 @@ public class Schedule {
       throw new IllegalArgumentException("Task cannot be null.");
     }
     tasks.add(task);
-  }
-
-  /**
-   * Processes task by removing task from the queue.
-   *
-   * @return matched Task, ResourceType pair
-   */
-  public Map<Task, ResourceType> processTask() {
-    Task task = tasks.remove();
-    ResourceType resourceType = matchTaskWithResource(task);
-    assignResourceToTask(resourceType, task);
-    Map<Task, ResourceType> pair = new HashMap<>();
-    pair.put(task, resourceType);
-    return pair;
-  }
-
-  /**
-   * Assigns the resource to a task until the specified end time.
-   *
-   * @param resourceType the resource type to assign a task to
-   * @param task         the task to be matched with resource
-   * @throws IllegalArgumentException if resourceType or task is null
-   */
-  public void assignResourceToTask(ResourceType resourceType, Task task) {
-    if (resourceType == null) {
-      throw new IllegalArgumentException("ResourceType cannot be null.");
-    }
-    if (task == null) {
-      throw new IllegalArgumentException("Task cannot be null.");
-    }
-    resourceType.findAvailableResource(task.getStartTime()).assignUntil(task.getEndTime());
-    task.getResources().remove(resourceType);
   }
 
   public String getScheduleId() {

--- a/LiveSched/src/test/java/dev/coms4156/project/livesched/ScheduleUnitTests.java
+++ b/LiveSched/src/test/java/dev/coms4156/project/livesched/ScheduleUnitTests.java
@@ -1,167 +1,158 @@
-// package dev.coms4156.project.livesched;
-//
-// import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-// import static org.junit.jupiter.api.Assertions.assertEquals;
-// import static org.junit.jupiter.api.Assertions.assertNull;
-// import static org.junit.jupiter.api.Assertions.assertThrows;
-// import static org.junit.jupiter.api.Assertions.assertTrue;
-//
-// import java.time.LocalDateTime;
-// import java.util.ArrayList;
-// import java.util.HashMap;
-// import java.util.List;
-// import java.util.Map;
-// import org.junit.jupiter.api.BeforeEach;
-// import org.junit.jupiter.api.Test;
-// import org.springframework.boot.test.context.SpringBootTest;
-// import org.springframework.test.context.ContextConfiguration;
-//
-// /**
-//  * Unit tests for the Schedule class.
-//  */
-// @SpringBootTest
-// @ContextConfiguration
-// public class ScheduleUnitTests {
-//
-//   private Schedule testSchedule;
-//   private String scheduleId = "TestSchedule";
-//   private List<ResourceType> resourceTypes;
-//   private double maxDistance = 10.0;
-//   private Task testTask;
-//   private ResourceType testResourceType;
-//
-//   /**
-//    * Set up to be run before all tests.
-//    */
-//   @BeforeEach
-//   void setupScheduleForTesting() {
-//     resourceTypes = new ArrayList<>();
-//     testResourceType = new ResourceType("Hospital", 5, 40.7128, -74.0060);
-//     resourceTypes.add(testResourceType);
-//
-//     testSchedule = new Schedule(scheduleId, resourceTypes, maxDistance);
-//
-//     Map<ResourceType, Integer> resourceList = new HashMap<>();
-//     resourceList.put(testResourceType, 1);
-//     LocalDateTime startTime = LocalDateTime.now().plusHours(1);
-//     LocalDateTime endTime = startTime.plusHours(2);
-//     testTask = new Task("TestTask", resourceList, 3, startTime, endTime, 40.7128, -74.0060);
-//   }
-//
-//   /**
-//    * Test for the constructor in Schedule class.
-//    */
-//   @Test
-//   void constructorTest() {
-//     assertDoesNotThrow(() -> new Schedule(scheduleId, resourceTypes, maxDistance),
-//         "Schedule constructor should not throw an exception with valid parameters.");
-//
-//     Exception exception = assertThrows(IllegalArgumentException.class,
-//         () -> new Schedule(null, resourceTypes, maxDistance),
-//         "Schedule constructor should throw an exception if scheduleId is null.");
-//     assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
-//
-//     exception = assertThrows(IllegalArgumentException.class,
-//         () -> new Schedule("  ", resourceTypes, maxDistance),
-//         "Schedule constructor should throw an exception if scheduleId is empty.");
-//     assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
-//
-//     exception = assertThrows(IllegalArgumentException.class,
-//         () -> new Schedule(scheduleId, null, maxDistance),
-//         "Schedule constructor should throw an exception if resourceTypes is null.");
-//     assertEquals("Resource types list cannot be null.", exception.getMessage());
-//
-//     exception = assertThrows(IllegalArgumentException.class,
-//         () -> new Schedule(scheduleId, resourceTypes, -1.0),
-//         "Schedule constructor should throw an exception if maxDistance is negative.");
-//     assertEquals("Maximum distance cannot be negative.", exception.getMessage());
-//   }
-//
-//   /**
-//    * Test for matchTaskWithResource method in Schedule class.
-//    */
-//   @Test
-//   void matchTaskWithResourceTest() {
-//     ResourceType result = testSchedule.matchTaskWithResource(testTask);
-//     assertEquals(testResourceType, result, "Should return the matching resource type.");
-//
-//     // Test with a task that requires more resources than available
-//     Map<ResourceType, Integer> resourceList = new HashMap<>();
-//     resourceList.put(testResourceType, 10);
-//     Task largeTask = new Task("LargeTask", resourceList, 3,
-//         LocalDateTime.now().plusHours(1), LocalDateTime.now().plusHours(3), 40.7128, -74.0060);
-//     result = testSchedule.matchTaskWithResource(largeTask);
-//     assertNull(result, "Should return null when no matching resource type is found.");
-//
-//     // Test with a task that is too far away
-//     Task farTask = new Task("FarTask", resourceList, 3,
-//         LocalDateTime.now().plusHours(1), LocalDateTime.now().plusHours(3), 51.5074, -0.1278);
-//     result = testSchedule.matchTaskWithResource(farTask);
-//     assertNull(result, "Should return null when task is too far from resource.");
-//
-//     // Test with null task
-//     Exception exception = assertThrows(IllegalArgumentException.class,
-//         () -> testSchedule.matchTaskWithResource(null),
-//         "Should throw IllegalArgumentException when task is null.");
-//     assertEquals("Task cannot be null.", exception.getMessage());
-//   }
-//
-//   /**
-//    * Test for receiveTask method in Schedule class.
-//    */
-//   @Test
-//   void receiveTaskTest() {
-//     assertDoesNotThrow(() -> testSchedule.receiveTask(testTask),
-//         "receiveTask should not throw an exception with a valid task.");
-//
-//     // Test with null task
-//     Exception exception = assertThrows(IllegalArgumentException.class,
-//         () -> testSchedule.receiveTask(null),
-//         "Should throw IllegalArgumentException when task is null.");
-//     assertEquals("Task cannot be null.", exception.getMessage());
-//   }
-//
-//   /**
-//    * Test for processTask method in Schedule class.
-//    */
-//   @Test
-//   void processTaskTest() {
-//     testSchedule.receiveTask(testTask);
-//
-//     Map<Task, ResourceType> result = testSchedule.processTask();
-//
-//     assertEquals(1, result.size(), "Should return one task-resource pair.");
-//     assertTrue(result.containsKey(testTask), "The processed task should be in the result.");
-//     assertEquals(testResourceType, result.get(testTask), "The resource type should match.");
-//   }
-//
-//   /**
-//    * Test for assignResourceToTask method in Schedule class.
-//    */
-//   @Test
-//   void assignResourceToTaskTest() {
-//     assertDoesNotThrow(() -> testSchedule.assignResourceToTask(testResourceType, testTask),
-//         "assignResourceToTask should not throw an exception with valid inputs.");
-//
-//     // Test with null resourceType
-//     Exception exception = assertThrows(IllegalArgumentException.class,
-//         () -> testSchedule.assignResourceToTask(null, testTask),
-//         "Should throw IllegalArgumentException when resourceType is null.");
-//     assertEquals("ResourceType cannot be null.", exception.getMessage());
-//
-//     // Test with null task
-//     exception = assertThrows(IllegalArgumentException.class,
-//         () -> testSchedule.assignResourceToTask(testResourceType, null),
-//         "Should throw IllegalArgumentException when task is null.");
-//     assertEquals("Task cannot be null.", exception.getMessage());
-//   }
-//
-//   /**
-//    * Test for getScheduleId method in Schedule class.
-//    */
-//   @Test
-//   void getScheduleIdTest() {
-//     assertEquals(scheduleId, testSchedule.getScheduleId(),
-//         "getScheduleId should return the correct schedule ID.");
-//   }
-// }
+package dev.coms4156.project.livesched;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Unit tests for the Schedule class.
+ */
+@SpringBootTest
+@ContextConfiguration
+public class ScheduleUnitTests {
+
+  private List<Task> mockTasks;
+  private ResourceType mockResourceType;
+  private Task mockTask1;
+  private Task mockTask2;
+  private Resource mockResource1;
+  private Resource mockResource2;
+  private Location taskLocation;
+  private Location resourceLocation;
+
+  private final String testScheduleId = "Schedule ID1";
+  private final double maxDistance = 100.0;
+  // private final double longitude = -73.96;
+
+  /**
+   * Set up to be run before all tests.
+   */
+  @BeforeEach
+  void setupScheduleForTesting() {
+    mockTask1 = mock(Task.class);
+    mockTask2 = mock(Task.class);
+    mockTasks = new ArrayList<Task>();
+    mockTasks.add(mockTask1);
+    mockTasks.add(mockTask2);
+
+    mockResource1 = mock(Resource.class);
+    mockResource2 = mock(Resource.class);
+    mockResourceType = mock(ResourceType.class);
+
+    taskLocation = mock(Location.class);
+    resourceLocation = mock(Location.class);
+    when(taskLocation.getDistance(any())).thenReturn(50.0);
+    when(resourceLocation.getDistance(any())).thenReturn(50.0);
+  }
+
+  /**
+   * Test for the constructor in Schedule class.
+   */
+  @Test
+  void constructorTest() {
+    assertDoesNotThrow(() -> new Schedule(testScheduleId, mockTasks, maxDistance),
+        "Schedule constructor should not throw an exception with valid parameters.");
+
+    Exception exception = assertThrows(IllegalArgumentException.class,
+        () -> new Schedule(null, mockTasks, maxDistance),
+        "Schedule constructor should throw an exception if scheduleId is null.");
+    assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
+
+    exception = assertThrows(IllegalArgumentException.class,
+        () -> new Schedule("  ", mockTasks, maxDistance),
+        "Schedule constructor should throw an exception if scheduleId is empty.");
+    assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
+
+    exception = assertThrows(IllegalArgumentException.class,
+        () -> new Schedule(testScheduleId, null, maxDistance),
+        "Schedule constructor should throw an exception if tasks is null.");
+    assertEquals("Tasks list cannot be null.", exception.getMessage());
+
+    exception = assertThrows(IllegalArgumentException.class,
+        () -> new Schedule(testScheduleId, mockTasks, -1.0),
+        "Schedule constructor should throw an exception if maxDistance is negative.");
+    assertEquals("Maximum distance cannot be negative.", exception.getMessage());
+  }
+
+  /**
+   * Test for createSchedule method in Schedule class.
+   */
+  @Test
+  void createScheduleTest() {
+
+    when(mockTask1.getResources()).thenReturn(Map.of(mockResourceType, 1));
+    when(mockTask1.getLocation()).thenReturn(taskLocation);
+    when(mockResourceType.getLocation()).thenReturn(resourceLocation);
+    when(mockResourceType.countAvailableUnits(any())).thenReturn(1);
+    when(mockResourceType.findAvailableResource(any())).thenReturn(mockResource1);
+
+    Schedule schedule = new Schedule(testScheduleId, mockTasks, maxDistance);
+    Map<Task, List<Resource>> taskSchedule = schedule.createSchedule();
+    assertTrue(taskSchedule.containsKey(mockTask1),
+        "Created schedule should contain mockTask1");
+    assertEquals(1, taskSchedule.get(mockTask1).size(),
+        "Created schedule should contain 1 resource for mockTask1");
+  }
+
+  /**
+   * Test for completeTask method in Schedule class.
+   */
+  @Test
+  void completeTaskTest() {
+    when(mockTask1.getResources()).thenReturn(Map.of(mockResourceType, 1));
+    when(mockTask1.getLocation()).thenReturn(taskLocation);
+    when(mockResourceType.getLocation()).thenReturn(resourceLocation);
+    when(mockResourceType.countAvailableUnits(any())).thenReturn(1);
+    when(mockResourceType.findAvailableResource(any())).thenReturn(mockResource1);
+
+    Schedule scheduleForInvalidTask = new Schedule(testScheduleId, mockTasks, maxDistance);
+    assertThrows(IllegalArgumentException.class,
+        () -> scheduleForInvalidTask.completeTask(mock(Task.class)),
+        "completeTask method should throw exception when completing invalid task");
+
+    Schedule scheduleForValidTask = new Schedule(testScheduleId, mockTasks, maxDistance);
+    scheduleForValidTask.createSchedule();
+    assertDoesNotThrow(() -> scheduleForValidTask.completeTask(mockTask1),
+        "completeTask method should not throw exception when completing valid task");
+    verify(mockResource1, times(1)).release();
+  }
+
+  /**
+   * Test for receiveTask method in Schedule class.
+   */
+  @Test
+  void receiveTaskTest() {
+    Schedule schedule = new Schedule(testScheduleId, mockTasks, maxDistance);
+    Task newTask = mock(Task.class);
+    schedule.receiveTask(newTask);
+    assertEquals(3, schedule.createSchedule().size(),
+        "Total tasks in Schedule object should update after receiveTask");
+
+    assertThrows(IllegalArgumentException.class, () -> schedule.receiveTask(null),
+        "receiveTask method should throw exception for null task value");
+  }
+
+  /**
+   * Test for getScheduleId method in Schedule class.
+   */
+  @Test
+  void getScheduleIdTest() {
+    Schedule testSchedule = new Schedule(testScheduleId, mockTasks, maxDistance);
+    assertEquals(testScheduleId, testSchedule.getScheduleId(),
+        "getScheduleId should return the correct schedule ID.");
+  }
+}

--- a/LiveSched/src/test/java/dev/coms4156/project/livesched/ScheduleUnitTests.java
+++ b/LiveSched/src/test/java/dev/coms4156/project/livesched/ScheduleUnitTests.java
@@ -1,167 +1,167 @@
-package dev.coms4156.project.livesched;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ContextConfiguration;
-
-/**
- * Unit tests for the Schedule class.
- */
-@SpringBootTest
-@ContextConfiguration
-public class ScheduleUnitTests {
-
-  private Schedule testSchedule;
-  private String scheduleId = "TestSchedule";
-  private List<ResourceType> resourceTypes;
-  private double maxDistance = 10.0;
-  private Task testTask;
-  private ResourceType testResourceType;
-
-  /**
-   * Set up to be run before all tests.
-   */
-  @BeforeEach
-  void setupScheduleForTesting() {
-    resourceTypes = new ArrayList<>();
-    testResourceType = new ResourceType("Hospital", 5, 40.7128, -74.0060);
-    resourceTypes.add(testResourceType);
-    
-    testSchedule = new Schedule(scheduleId, resourceTypes, maxDistance);
-    
-    Map<ResourceType, Integer> resourceList = new HashMap<>();
-    resourceList.put(testResourceType, 1);
-    LocalDateTime startTime = LocalDateTime.now().plusHours(1);
-    LocalDateTime endTime = startTime.plusHours(2);
-    testTask = new Task("TestTask", resourceList, 3, startTime, endTime, 40.7128, -74.0060);
-  }
-
-  /**
-   * Test for the constructor in Schedule class.
-   */
-  @Test
-  void constructorTest() {
-    assertDoesNotThrow(() -> new Schedule(scheduleId, resourceTypes, maxDistance),
-        "Schedule constructor should not throw an exception with valid parameters.");
-
-    Exception exception = assertThrows(IllegalArgumentException.class, 
-        () -> new Schedule(null, resourceTypes, maxDistance),
-        "Schedule constructor should throw an exception if scheduleId is null.");
-    assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
-
-    exception = assertThrows(IllegalArgumentException.class, 
-        () -> new Schedule("  ", resourceTypes, maxDistance),
-        "Schedule constructor should throw an exception if scheduleId is empty.");
-    assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
-
-    exception = assertThrows(IllegalArgumentException.class, 
-        () -> new Schedule(scheduleId, null, maxDistance),
-        "Schedule constructor should throw an exception if resourceTypes is null.");
-    assertEquals("Resource types list cannot be null.", exception.getMessage());
-
-    exception = assertThrows(IllegalArgumentException.class, 
-        () -> new Schedule(scheduleId, resourceTypes, -1.0),
-        "Schedule constructor should throw an exception if maxDistance is negative.");
-    assertEquals("Maximum distance cannot be negative.", exception.getMessage());
-  }
-
-  /**
-   * Test for matchTaskWithResource method in Schedule class.
-   */
-  @Test
-  void matchTaskWithResourceTest() {
-    ResourceType result = testSchedule.matchTaskWithResource(testTask);
-    assertEquals(testResourceType, result, "Should return the matching resource type.");
-
-    // Test with a task that requires more resources than available
-    Map<ResourceType, Integer> resourceList = new HashMap<>();
-    resourceList.put(testResourceType, 10);
-    Task largeTask = new Task("LargeTask", resourceList, 3, 
-        LocalDateTime.now().plusHours(1), LocalDateTime.now().plusHours(3), 40.7128, -74.0060);
-    result = testSchedule.matchTaskWithResource(largeTask);
-    assertNull(result, "Should return null when no matching resource type is found.");
-
-    // Test with a task that is too far away
-    Task farTask = new Task("FarTask", resourceList, 3, 
-        LocalDateTime.now().plusHours(1), LocalDateTime.now().plusHours(3), 51.5074, -0.1278);
-    result = testSchedule.matchTaskWithResource(farTask);
-    assertNull(result, "Should return null when task is too far from resource.");
-
-    // Test with null task
-    Exception exception = assertThrows(IllegalArgumentException.class, 
-        () -> testSchedule.matchTaskWithResource(null),
-        "Should throw IllegalArgumentException when task is null.");
-    assertEquals("Task cannot be null.", exception.getMessage());
-  }
-
-  /**
-   * Test for receiveTask method in Schedule class.
-   */
-  @Test
-  void receiveTaskTest() {
-    assertDoesNotThrow(() -> testSchedule.receiveTask(testTask),
-        "receiveTask should not throw an exception with a valid task.");
-
-    // Test with null task
-    Exception exception = assertThrows(IllegalArgumentException.class, 
-        () -> testSchedule.receiveTask(null),
-        "Should throw IllegalArgumentException when task is null.");
-    assertEquals("Task cannot be null.", exception.getMessage());
-  }
-
-  /**
-   * Test for processTask method in Schedule class.
-   */
-  @Test
-  void processTaskTest() {
-    testSchedule.receiveTask(testTask);
-
-    Map<Task, ResourceType> result = testSchedule.processTask();
-    
-    assertEquals(1, result.size(), "Should return one task-resource pair.");
-    assertTrue(result.containsKey(testTask), "The processed task should be in the result.");
-    assertEquals(testResourceType, result.get(testTask), "The resource type should match.");
-  }
-
-  /**
-   * Test for assignResourceToTask method in Schedule class.
-   */
-  @Test
-  void assignResourceToTaskTest() {
-    assertDoesNotThrow(() -> testSchedule.assignResourceToTask(testResourceType, testTask),
-        "assignResourceToTask should not throw an exception with valid inputs.");
-
-    // Test with null resourceType
-    Exception exception = assertThrows(IllegalArgumentException.class, 
-        () -> testSchedule.assignResourceToTask(null, testTask),
-        "Should throw IllegalArgumentException when resourceType is null.");
-    assertEquals("ResourceType cannot be null.", exception.getMessage());
-
-    // Test with null task
-    exception = assertThrows(IllegalArgumentException.class, 
-        () -> testSchedule.assignResourceToTask(testResourceType, null),
-        "Should throw IllegalArgumentException when task is null.");
-    assertEquals("Task cannot be null.", exception.getMessage());
-  }
-
-  /**
-   * Test for getScheduleId method in Schedule class.
-   */
-  @Test
-  void getScheduleIdTest() {
-    assertEquals(scheduleId, testSchedule.getScheduleId(), 
-        "getScheduleId should return the correct schedule ID.");
-  }
-}
+// package dev.coms4156.project.livesched;
+//
+// import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+// import static org.junit.jupiter.api.Assertions.assertEquals;
+// import static org.junit.jupiter.api.Assertions.assertNull;
+// import static org.junit.jupiter.api.Assertions.assertThrows;
+// import static org.junit.jupiter.api.Assertions.assertTrue;
+//
+// import java.time.LocalDateTime;
+// import java.util.ArrayList;
+// import java.util.HashMap;
+// import java.util.List;
+// import java.util.Map;
+// import org.junit.jupiter.api.BeforeEach;
+// import org.junit.jupiter.api.Test;
+// import org.springframework.boot.test.context.SpringBootTest;
+// import org.springframework.test.context.ContextConfiguration;
+//
+// /**
+//  * Unit tests for the Schedule class.
+//  */
+// @SpringBootTest
+// @ContextConfiguration
+// public class ScheduleUnitTests {
+//
+//   private Schedule testSchedule;
+//   private String scheduleId = "TestSchedule";
+//   private List<ResourceType> resourceTypes;
+//   private double maxDistance = 10.0;
+//   private Task testTask;
+//   private ResourceType testResourceType;
+//
+//   /**
+//    * Set up to be run before all tests.
+//    */
+//   @BeforeEach
+//   void setupScheduleForTesting() {
+//     resourceTypes = new ArrayList<>();
+//     testResourceType = new ResourceType("Hospital", 5, 40.7128, -74.0060);
+//     resourceTypes.add(testResourceType);
+//
+//     testSchedule = new Schedule(scheduleId, resourceTypes, maxDistance);
+//
+//     Map<ResourceType, Integer> resourceList = new HashMap<>();
+//     resourceList.put(testResourceType, 1);
+//     LocalDateTime startTime = LocalDateTime.now().plusHours(1);
+//     LocalDateTime endTime = startTime.plusHours(2);
+//     testTask = new Task("TestTask", resourceList, 3, startTime, endTime, 40.7128, -74.0060);
+//   }
+//
+//   /**
+//    * Test for the constructor in Schedule class.
+//    */
+//   @Test
+//   void constructorTest() {
+//     assertDoesNotThrow(() -> new Schedule(scheduleId, resourceTypes, maxDistance),
+//         "Schedule constructor should not throw an exception with valid parameters.");
+//
+//     Exception exception = assertThrows(IllegalArgumentException.class,
+//         () -> new Schedule(null, resourceTypes, maxDistance),
+//         "Schedule constructor should throw an exception if scheduleId is null.");
+//     assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
+//
+//     exception = assertThrows(IllegalArgumentException.class,
+//         () -> new Schedule("  ", resourceTypes, maxDistance),
+//         "Schedule constructor should throw an exception if scheduleId is empty.");
+//     assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
+//
+//     exception = assertThrows(IllegalArgumentException.class,
+//         () -> new Schedule(scheduleId, null, maxDistance),
+//         "Schedule constructor should throw an exception if resourceTypes is null.");
+//     assertEquals("Resource types list cannot be null.", exception.getMessage());
+//
+//     exception = assertThrows(IllegalArgumentException.class,
+//         () -> new Schedule(scheduleId, resourceTypes, -1.0),
+//         "Schedule constructor should throw an exception if maxDistance is negative.");
+//     assertEquals("Maximum distance cannot be negative.", exception.getMessage());
+//   }
+//
+//   /**
+//    * Test for matchTaskWithResource method in Schedule class.
+//    */
+//   @Test
+//   void matchTaskWithResourceTest() {
+//     ResourceType result = testSchedule.matchTaskWithResource(testTask);
+//     assertEquals(testResourceType, result, "Should return the matching resource type.");
+//
+//     // Test with a task that requires more resources than available
+//     Map<ResourceType, Integer> resourceList = new HashMap<>();
+//     resourceList.put(testResourceType, 10);
+//     Task largeTask = new Task("LargeTask", resourceList, 3,
+//         LocalDateTime.now().plusHours(1), LocalDateTime.now().plusHours(3), 40.7128, -74.0060);
+//     result = testSchedule.matchTaskWithResource(largeTask);
+//     assertNull(result, "Should return null when no matching resource type is found.");
+//
+//     // Test with a task that is too far away
+//     Task farTask = new Task("FarTask", resourceList, 3,
+//         LocalDateTime.now().plusHours(1), LocalDateTime.now().plusHours(3), 51.5074, -0.1278);
+//     result = testSchedule.matchTaskWithResource(farTask);
+//     assertNull(result, "Should return null when task is too far from resource.");
+//
+//     // Test with null task
+//     Exception exception = assertThrows(IllegalArgumentException.class,
+//         () -> testSchedule.matchTaskWithResource(null),
+//         "Should throw IllegalArgumentException when task is null.");
+//     assertEquals("Task cannot be null.", exception.getMessage());
+//   }
+//
+//   /**
+//    * Test for receiveTask method in Schedule class.
+//    */
+//   @Test
+//   void receiveTaskTest() {
+//     assertDoesNotThrow(() -> testSchedule.receiveTask(testTask),
+//         "receiveTask should not throw an exception with a valid task.");
+//
+//     // Test with null task
+//     Exception exception = assertThrows(IllegalArgumentException.class,
+//         () -> testSchedule.receiveTask(null),
+//         "Should throw IllegalArgumentException when task is null.");
+//     assertEquals("Task cannot be null.", exception.getMessage());
+//   }
+//
+//   /**
+//    * Test for processTask method in Schedule class.
+//    */
+//   @Test
+//   void processTaskTest() {
+//     testSchedule.receiveTask(testTask);
+//
+//     Map<Task, ResourceType> result = testSchedule.processTask();
+//
+//     assertEquals(1, result.size(), "Should return one task-resource pair.");
+//     assertTrue(result.containsKey(testTask), "The processed task should be in the result.");
+//     assertEquals(testResourceType, result.get(testTask), "The resource type should match.");
+//   }
+//
+//   /**
+//    * Test for assignResourceToTask method in Schedule class.
+//    */
+//   @Test
+//   void assignResourceToTaskTest() {
+//     assertDoesNotThrow(() -> testSchedule.assignResourceToTask(testResourceType, testTask),
+//         "assignResourceToTask should not throw an exception with valid inputs.");
+//
+//     // Test with null resourceType
+//     Exception exception = assertThrows(IllegalArgumentException.class,
+//         () -> testSchedule.assignResourceToTask(null, testTask),
+//         "Should throw IllegalArgumentException when resourceType is null.");
+//     assertEquals("ResourceType cannot be null.", exception.getMessage());
+//
+//     // Test with null task
+//     exception = assertThrows(IllegalArgumentException.class,
+//         () -> testSchedule.assignResourceToTask(testResourceType, null),
+//         "Should throw IllegalArgumentException when task is null.");
+//     assertEquals("Task cannot be null.", exception.getMessage());
+//   }
+//
+//   /**
+//    * Test for getScheduleId method in Schedule class.
+//    */
+//   @Test
+//   void getScheduleIdTest() {
+//     assertEquals(scheduleId, testSchedule.getScheduleId(),
+//         "getScheduleId should return the correct schedule ID.");
+//   }
+// }


### PR DESCRIPTION
 This PR

- Updates schedule class - more details below
- Updates schedule class unit tests
- Comments out Schedule unit tests - will add new ones in the next PR
- Passes PMD check
- Passes checkstyle
- Modifies Jacoco coverage to 68% 

Schedule class is now constructed only with allTasks as they already contain ResourceTypes which contain resources.
The createSchedule method returns a list of doable tasks and the resources assigned to the task until task end time.