### PR TITLE
Refined addTask API to return JSON object instead of String

### DIFF
--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
@@ -148,15 +148,15 @@ public class RouteController {
   /**
    * Attempts to add a task to the database.
    *
+   * @param taskName       A {@code String} representing the name of the new task.
    * @param priority       A {@code int} representing the priority of the new task.
    * @param startTime      A {@code String} representing the start time of the new task.
    * @param endTime        A {@code String} representing the end time of the new task.
    * @param latitude       A {@code double} representing the latitude of the new task.
    * @param longitude      A {@code double} representing the longitude of the new task.
    *
-   * @return               A {@code ResponseEntity} object containing an HTTP 200
-   *                       response with an appropriate message or the proper status
-   *                       code in tune with what has happened.
+   * @return A {@code ResponseEntity} object containing the created Task object and an HTTP 200
+   *          status code or the proper status code in tune with what has happened.
    */
   @PatchMapping(value = "/addTask", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> addTask(@RequestParam(value = "taskName") String taskName,
@@ -174,7 +174,7 @@ public class RouteController {
       Task newTask = new Task(taskId, taskName, resourceTypeList, priority,
               startTimeFormatted, endTimeFormatted, latitude, longitude);
       LiveSchedApplication.myFileDatabase.addTask(newTask);
-      return new ResponseEntity<>("Attribute was updated successfully.", HttpStatus.OK);
+      return new ResponseEntity<>(newTask, HttpStatus.OK);
     } catch (Exception e) {
       return handleException(e);
     }

--- a/LiveSched/src/test/java/dev/coms4156/project/livesched/RouteControllerUnitTests.java
+++ b/LiveSched/src/test/java/dev/coms4156/project/livesched/RouteControllerUnitTests.java
@@ -190,7 +190,8 @@ public class RouteControllerUnitTests {
         endTime, latitude, longitude);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
-    assertEquals("Attribute was updated successfully.", response.getBody());
+    Task responseBody = (Task) response.getBody();
+    assertEquals("3", responseBody.getTaskId(), "New task ID should match '3'");
     assertEquals(initialSize + 1, testDatabase.getAllTasks().size());
   }
 

--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ This section describes the endpoints that the service provides, as well as their
   * HTTP 500 Status Code with "An Error has occurred" if an unexpected error occurs.
 
 #### PATCH /addTask
-* Expected Input Parameters: priority (int), startTime (String), endTime (String), latitude (double), longitude (double)
-* Expected Output: A String confirming the task was added successfully. (ResponseEntity\<String\>)
+* Expected Input Parameters: taskName (String), priority (int), startTime (String), endTime (String), latitude (double), longitude (double)
+* Expected Output: A JSON object containing the details of the newly added task
 * Attempts to add a task to the database.
 * Upon Success:
-  * HTTP 200 Status Code with "Attribute was updated successfully." in the response body.
+  * HTTP 200 Status Code with the task's details in the response body.
 * Upon Failure:
   * HTTP 500 Status Code with "An Error has occurred" if an unexpected error occurs.
  


### PR DESCRIPTION
This PR:

- Refined the addTask API to return the Task object instead of a String message when the task is successfully added
- Modified the addTask unit test
- Modified addTask description in README
- Passes checkstyle and PMD