### PR TITLE
Modified updateResource method in Task class

### DIFF
--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/Task.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/Task.java
@@ -135,7 +135,7 @@ public class Task implements Serializable {
   }
 
   /**
-   * Updates the quantity of or add a resource needed for the task.
+   * Updates the quantity of, add, or remove a resource needed for the task.
    *
    * @param resourceType  the type of resource needed
    * @param quantity      the quantity of the resource needed
@@ -149,11 +149,24 @@ public class Task implements Serializable {
     if (quantity < 0) {
       throw new IllegalArgumentException("Quantity cannot be negative.");
     }
-    
-    if (resourceList.containsKey(resourceType)) {
-      resourceList.replace(resourceType, quantity);
+
+    // Find an existing ResourceType with the same typeName
+    ResourceType existingType = null;
+    for (ResourceType type : resourceList.keySet()) {
+      if (type.getTypeName().equals(resourceType.getTypeName())) {
+        existingType = type;
+        break;
+      }
+    }
+
+    if (existingType != null) {
+      if (quantity == 0) {
+        resourceList.remove(existingType); // Remove existing ResourceType from the list
+      } else {
+        resourceList.replace(existingType, quantity); // Update quantity of existing ResourceType
+      }
     } else {
-      resourceList.put(resourceType, quantity);
+      resourceList.put(resourceType, quantity); // Add new ResourceType and its quantity
     }
   }
 

--- a/LiveSched/src/test/java/dev/coms4156/project/livesched/TaskUnitTests.java
+++ b/LiveSched/src/test/java/dev/coms4156/project/livesched/TaskUnitTests.java
@@ -2,6 +2,7 @@ package dev.coms4156.project.livesched;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -227,6 +228,11 @@ public class TaskUnitTests {
     assertThrows(IllegalArgumentException.class, () ->
         testTask.updateResource(newResourceType, -1),
         "Quantity for new resource type should not be negative.");
+
+    testTask.updateResource(newResourceType, 0);
+
+    assertFalse(testTask.getResources().containsKey(newResourceType),
+        "New resource type should be removed from the resource list.");
   }
 
   /**


### PR DESCRIPTION
This PR:

- Fixed updateResource method in the Task class to compare the typeName to determine if a resourceType already exists in the resourceList (before the fix, even if there is Nurse: 2 in the list, it created another Nurse: 5 in the list when update is requested)
- Added handling of quantity = 0; in that case, the resourceType gets removed from the list
- Added a small test for the above
- Passes checkstyle (but I think the previous PR didn't pass checkstyle for RouteController and MyFileDatabase)