### PR TITLE
Modify Schedule and update API endpoints

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,19 +30,19 @@ jobs:
         run: |
           mvn checkstyle:checkstyle --file LiveSched/pom.xml
           mkdir -p reports
-          cp target/site/checkstyle.html reports/checkstyle.html
+          cp LiveSched/target/site/checkstyle.html reports/checkstyle.html
         continue-on-error: true
 
       - name: PMD Static Analysis
         run: |
           mvn pmd:check --file LiveSched/pom.xml
-          cp target/pmd.xml reports/pmd.xml
+          cp LiveSched/target/pmd.xml reports/pmd.xml
         continue-on-error: true
 
       - name: JaCoCo Branch Coverage
         run: |
           mvn jacoco:report --file LiveSched/pom.xml
-          cp target/site/jacoco/index.html reports/jacoco.html
+          cp LiveSched/target/site/jacoco/index.html reports/jacoco.html
         continue-on-error: true
 
       - name: Upload Reports

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,9 +28,9 @@ jobs:
 
       - name: Checkstyle Analysis
         run: |
-          mvn checkstyle:check --file LiveSched/pom.xml
+          mvn checkstyle:checkstyle --file LiveSched/pom.xml
           mkdir -p reports/checkstyle
-          cp LiveSched/target/checkstyle-result.xml reports/checkstyle/checkstyle-result.xml
+          cp -r LiveSched/target/site/* reports/checkstyle/
         continue-on-error: true
 
       - name: PMD Static Analysis
@@ -44,7 +44,7 @@ jobs:
         run: |
           mvn jacoco:report --file LiveSched/pom.xml
           mkdir -p reports/jacoco
-          cp -r LiveSched/target/site/* reports/jacoco/
+          cp -r LiveSched/target/site/jacoco/* reports/jacoco/
         continue-on-error: true
 
       - name: Upload Reports

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,4 +24,29 @@ jobs:
           cache: maven
 
       - name: Build and Test with Maven
-        run: mvn -B clean install --file LiveSched/pom.xml
+        run: mvn -B clean test --file LiveSched/pom.xml
+
+      - name: Checkstyle Analysis
+        run: |
+          mvn checkstyle:checkstyle --file LiveSched/pom.xml
+          mkdir -p reports
+          cp target/site/checkstyle.html reports/checkstyle.html
+        continue-on-error: true
+
+      - name: PMD Static Analysis
+        run: |
+          mvn pmd:check --file LiveSched/pom.xml
+          cp target/pmd.xml reports/pmd.xml
+        continue-on-error: true
+
+      - name: JaCoCo Branch Coverage
+        run: |
+          mvn jacoco:report --file LiveSched/pom.xml
+          cp target/site/jacoco/index.html reports/jacoco.html
+        continue-on-error: true
+
+      - name: Upload Reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-reports
+          path: reports/

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,21 +28,23 @@ jobs:
 
       - name: Checkstyle Analysis
         run: |
-          mvn checkstyle:checkstyle --file LiveSched/pom.xml
-          mkdir -p reports
-          cp LiveSched/target/site/checkstyle.html reports/checkstyle.html
+          mvn checkstyle:check --file LiveSched/pom.xml
+          mkdir -p reports/checkstyle
+          cp LiveSched/target/checkstyle-result.xml reports/checkstyle/checkstyle-result.xml
         continue-on-error: true
 
       - name: PMD Static Analysis
         run: |
           mvn pmd:check --file LiveSched/pom.xml
-          cp LiveSched/target/pmd.xml reports/pmd.xml
+          mkdir -p reports/pmd
+          cp -r LiveSched/target/reports/* reports/pmd/
         continue-on-error: true
 
       - name: JaCoCo Branch Coverage
         run: |
           mvn jacoco:report --file LiveSched/pom.xml
-          cp LiveSched/target/site/jacoco/index.html reports/jacoco.html
+          mkdir -p reports/jacoco
+          cp -r LiveSched/target/site/* reports/jacoco/
         continue-on-error: true
 
       - name: Upload Reports

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
@@ -22,6 +22,7 @@ public class RouteController {
 
   private static final String TASK_ID = "taskId";
   private static final String CLIENT_ID = "clientId";
+  private static final String TASK_NOT_FOUND = "Task Not Found";
 
   /**
    * Redirects to the homepage.
@@ -76,7 +77,7 @@ public class RouteController {
       Task task = LiveSchedApplication.getClientFileDatabase(clientId).getTaskById(taskId);
 
       if (task == null) {
-        return new ResponseEntity<>("Task Not Found", HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(TASK_NOT_FOUND, HttpStatus.NOT_FOUND);
       } else {
         return new ResponseEntity<>(task, HttpStatus.OK);
       }
@@ -115,61 +116,31 @@ public class RouteController {
   }
 
   /**
-   * Returns the details of all schedules in the database.
+   * Returns the details of the master schedule in the database.
    *
-   * @param clientId A {@code String} representing the client that owns the schedules
-   *
-   * @return A {@code ResponseEntity} object containing either a list of all Schedules and
-   *         an HTTP 200 response, or an appropriate message indicating the proper response.
-   */
-  @GetMapping(value = "/retrieveSchedules", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> retrieveSchedules(@RequestParam(value = CLIENT_ID) String clientId) {
-    try {
-      List<Schedule> scheduleList =
-          LiveSchedApplication.getClientFileDatabase(clientId).getAllSchedules();
-
-      if (scheduleList == null || scheduleList.isEmpty()) {
-        return new ResponseEntity<>("Schedules Not Found", HttpStatus.NOT_FOUND);
-      } else {
-        return new ResponseEntity<>(scheduleList, HttpStatus.OK);
-      }
-
-    } catch (Exception e) {
-      return handleException(e);
-    }
-  }
-
-  /**
-   * Returns the details of a specified schedule in the database.
-   *
-   * @param scheduleId     A {@code String} representing the schedule the user wishes
-   *                       to retrieve.
    * @param clientId       A {@code String} representing the client that owns the schedule
    *
-   *
-   * @return A {@code ResponseEntity} object containing either the details of the Task and
+   * @return A {@code ResponseEntity} object containing the master schedule and
    *         an HTTP 200 response or, an appropriate message indicating the proper response.
    */
   @GetMapping(value = "/retrieveSchedule", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> retrieveSchedule(@RequestParam(value = "scheduleId") String scheduleId,
-                                            @RequestParam(value = CLIENT_ID) String clientId) {
+  public ResponseEntity<?> retrieveSchedule(@RequestParam(value = CLIENT_ID) String clientId) {
     try {
-      Schedule schedule =
-          LiveSchedApplication.getClientFileDatabase(clientId).getScheduleById(scheduleId);
+      Schedule masterSchedule =
+          LiveSchedApplication.getClientFileDatabase(clientId).getMasterSchedule();
 
-      if (schedule == null) {
-        return new ResponseEntity<>("Schedule Not Found", HttpStatus.NOT_FOUND);
+      if (masterSchedule == null || masterSchedule.getTaskSchedule().isEmpty()) {
+        return new ResponseEntity<>("No Schedule Found", HttpStatus.NOT_FOUND);
       } else {
-        return new ResponseEntity<>(schedule, HttpStatus.OK);
+        return new ResponseEntity<>(masterSchedule.getTaskSchedule(), HttpStatus.OK);
       }
-
     } catch (Exception e) {
       return handleException(e);
     }
   }
 
   /**
-   * Returns the schedule for user tasks and resources.
+   * Update and returns the schedule for current tasks and resources.
    *
    * @param maxDistance    A {@code double} representing the max distance
    *                       the user wishes between schedule tasks and resources.
@@ -179,8 +150,8 @@ public class RouteController {
    * @return A {@code ResponseEntity} object containing either the details of the Schedule and
    *         an HTTP 200 response or, an appropriate message indicating the proper response.
    */
-  @GetMapping(value = "/createSchedule", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> createSchedule(@RequestParam(value = "maxDistance") double maxDistance,
+  @PatchMapping(value = "/updateSchedule", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<?> updateSchedule(@RequestParam(value = "maxDistance") double maxDistance,
                                           @RequestParam(value = CLIENT_ID) String clientId) {
     try {
       MyFileDatabase myFileDatabase = LiveSchedApplication.getClientFileDatabase(clientId);
@@ -188,15 +159,17 @@ public class RouteController {
 
       if (taskList == null || taskList.isEmpty()) {
         return new ResponseEntity<>("Tasks Not Found", HttpStatus.NOT_FOUND);
-      } else {
-        String scheduleId =
-            String.valueOf(myFileDatabase.getAllSchedules().size() + 1);
-        Schedule newSchedule = new Schedule(scheduleId, taskList, maxDistance);
-        newSchedule.createSchedule();
-        myFileDatabase.addSchedule(newSchedule);
-        return new ResponseEntity<>(newSchedule, HttpStatus.OK);
       }
 
+      Schedule masterSchedule = myFileDatabase.getMasterSchedule();
+
+      if (masterSchedule == null) {
+        return new ResponseEntity<>("Master Schedule Not Found", HttpStatus.NOT_FOUND);
+      }
+
+      Map<Task, List<Resource>> updatedSchedule =
+          masterSchedule.updateSchedule(taskList, maxDistance);
+      return new ResponseEntity<>(updatedSchedule, HttpStatus.OK);
     } catch (Exception e) {
       return handleException(e);
     }
@@ -241,11 +214,10 @@ public class RouteController {
   }
 
   /**
-   * Attempts to unschedule a task from a specific schedule in database.
+   * Attempts to unschedule a task from the master schedule in database.
    *
    * @param taskId        A {@code String} representing the id of the task
    *                      to be removed from schedule.
-   * @param scheduleId    A {@code String} representing the id of the schedule to be modified.
    * @param clientId      A {@code String} representing the client owner of the schedule/task.
    *
    * @return A {@code ResponseEntity} object containing the modified Schedule and an HTTP 200
@@ -253,15 +225,23 @@ public class RouteController {
    */
   @PatchMapping(value = "/unscheduleTask", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> unscheduleTask(@RequestParam(value = TASK_ID) String taskId,
-                                          @RequestParam(value = "scheduleId") String scheduleId,
                                           @RequestParam(value = CLIENT_ID) String clientId) {
     try {
       MyFileDatabase myFileDatabase = LiveSchedApplication.getClientFileDatabase(clientId);
-      Schedule schedule = myFileDatabase.getScheduleById(scheduleId);
+      Schedule masterSchedule = myFileDatabase.getMasterSchedule();
       Task task = myFileDatabase.getTaskById(taskId);
-      schedule.unscheduleTask(task);
-      Map<Task, List<Resource>> newSchedule = schedule.getTaskSchedule();
-      return new ResponseEntity<>(newSchedule, HttpStatus.OK);
+
+      if (task == null) {
+        return new ResponseEntity<>(TASK_NOT_FOUND, HttpStatus.NOT_FOUND);
+      }
+      if (masterSchedule == null) {
+        return new ResponseEntity<>("Master Schedule Not Found", HttpStatus.NOT_FOUND);
+      }
+      if (!masterSchedule.getTaskSchedule().containsKey(task)) {
+        return new ResponseEntity<>("Task Not Scheduled Yet", HttpStatus.BAD_REQUEST);
+      }
+      masterSchedule.unscheduleTask(task);
+      return new ResponseEntity<>(masterSchedule.getTaskSchedule(), HttpStatus.OK);
     } catch (Exception e) {
       return handleException(e);
     }
@@ -285,7 +265,7 @@ public class RouteController {
       Task task;
       task = myFileDatabase.getTaskById(taskId);
       if (task == null) {
-        return new ResponseEntity<>("Task Not Found", HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(TASK_NOT_FOUND, HttpStatus.NOT_FOUND);
       } else {
         myFileDatabase.deleteTask(task);
         return new ResponseEntity<>(taskId + " successfully deleted", HttpStatus.OK);
@@ -356,7 +336,7 @@ public class RouteController {
         }
         return new ResponseEntity<>("ResourceType Not Found", HttpStatus.NOT_FOUND);
       }
-      return new ResponseEntity<>("Task Not Found", HttpStatus.NOT_FOUND);
+      return new ResponseEntity<>(TASK_NOT_FOUND, HttpStatus.NOT_FOUND);
     } catch (Exception e) {
       return handleException(e);
     }

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/Task.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/Task.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a task that has to be done. 
@@ -202,6 +203,23 @@ public class Task implements Serializable {
    */
   public void updateLocation(double latitude, double longitude) {
     this.location = new Location(latitude, longitude);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    Task task = (Task) obj;
+    return Objects.equals(taskId, task.taskId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(taskId);
   }
 
   public Map<ResourceType, Integer> getResources() {

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/TaskComparator.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/TaskComparator.java
@@ -1,11 +1,16 @@
 package dev.coms4156.project.livesched;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * Comparator class for sorting Task by its priority.
  */
-public class TaskComparator implements Comparator<Task> {
+public class TaskComparator implements Comparator<Task>, Serializable {
+  @Serial
+  private static final long serialVersionUID = 1006L;
+
   @Override
   public int compare(Task x, Task y) {
     if (x.getPriority() < y.getPriority()) {

--- a/LiveSched/src/test/java/dev/coms4156/project/livesched/MyFileDatabaseUnitTests.java
+++ b/LiveSched/src/test/java/dev/coms4156/project/livesched/MyFileDatabaseUnitTests.java
@@ -41,7 +41,7 @@ class MyFileDatabaseUnitTests {
     assertNotNull(database);
     assertTrue(database.getAllTasks().isEmpty());
     assertTrue(database.getAllResourceTypes().isEmpty());
-    assertTrue(database.getAllSchedules().isEmpty());
+    assertTrue(database.getMasterSchedule().getTaskSchedule().isEmpty());
   }
 
   @Test
@@ -61,11 +61,12 @@ class MyFileDatabaseUnitTests {
   }
 
   @Test
-  void testSetAndGetAllSchedules() {
-    List<Schedule> schedules = new ArrayList<>();
-    schedules.add(createDummySchedule());
-    database.setAllSchedules(schedules);
-    assertEquals(1, database.getAllSchedules().size());
+  void testSetAndGetMasterSchedule() {
+    List<Task> tasks = new ArrayList<>();
+    tasks.add(createDummyTask());
+    Schedule schedule = new Schedule();
+    database.setMasterSchedule(schedule);
+    assertNotNull(database.getMasterSchedule());
   }
 
   @Test
@@ -82,14 +83,9 @@ class MyFileDatabaseUnitTests {
     database.setAllResourceTypes(null);
     assertTrue(database.getAllResourceTypes().isEmpty());
 
-    database.setAllSchedules(null);
-    assertTrue(database.getAllSchedules().isEmpty());
-  }
-
-  @Test
-  void testToString() {
-    // As the toString method is not implemented, we just check it doesn't throw an exception
-    assertDoesNotThrow(() -> database.toString());
+    database.setMasterSchedule(null);
+    assertNotNull(database.getMasterSchedule());
+    assertTrue(database.getMasterSchedule().getTaskSchedule().isEmpty());
   }
 
   private Task createDummyTask() {
@@ -104,7 +100,4 @@ class MyFileDatabaseUnitTests {
     return new ResourceType("DummyResource", 5, 0, 0);
   }
 
-  private Schedule createDummySchedule() {
-    return new Schedule("DummySchedule", new ArrayList<>(), 10);
-  }
 }

--- a/LiveSched/src/test/java/dev/coms4156/project/livesched/ScheduleUnitTests.java
+++ b/LiveSched/src/test/java/dev/coms4156/project/livesched/ScheduleUnitTests.java
@@ -34,7 +34,6 @@ public class ScheduleUnitTests {
   private Location taskLocation;
   private Location resourceLocation;
 
-  private final String testScheduleId = "Schedule ID1";
   private final double maxDistance = 100.0;
   // private final double longitude = -73.96;
 
@@ -64,28 +63,8 @@ public class ScheduleUnitTests {
    */
   @Test
   void constructorTest() {
-    assertDoesNotThrow(() -> new Schedule(testScheduleId, mockTasks, maxDistance),
-        "Schedule constructor should not throw an exception with valid parameters.");
-
-    Exception exception = assertThrows(IllegalArgumentException.class,
-        () -> new Schedule(null, mockTasks, maxDistance),
-        "Schedule constructor should throw an exception if scheduleId is null.");
-    assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
-
-    exception = assertThrows(IllegalArgumentException.class,
-        () -> new Schedule("  ", mockTasks, maxDistance),
-        "Schedule constructor should throw an exception if scheduleId is empty.");
-    assertEquals("Schedule ID cannot be null or empty.", exception.getMessage());
-
-    exception = assertThrows(IllegalArgumentException.class,
-        () -> new Schedule(testScheduleId, null, maxDistance),
-        "Schedule constructor should throw an exception if tasks is null.");
-    assertEquals("Tasks list cannot be null.", exception.getMessage());
-
-    exception = assertThrows(IllegalArgumentException.class,
-        () -> new Schedule(testScheduleId, mockTasks, -1.0),
-        "Schedule constructor should throw an exception if maxDistance is negative.");
-    assertEquals("Maximum distance cannot be negative.", exception.getMessage());
+    assertDoesNotThrow(() -> new Schedule(),
+        "Schedule constructor should not throw an exception.");
   }
 
   /**
@@ -93,15 +72,14 @@ public class ScheduleUnitTests {
    */
   @Test
   void createScheduleTest() {
-
     when(mockTask1.getResources()).thenReturn(Map.of(mockResourceType, 1));
     when(mockTask1.getLocation()).thenReturn(taskLocation);
     when(mockResourceType.getLocation()).thenReturn(resourceLocation);
     when(mockResourceType.countAvailableUnits(any())).thenReturn(1);
     when(mockResourceType.findAvailableResource(any())).thenReturn(mockResource1);
 
-    Schedule schedule = new Schedule(testScheduleId, mockTasks, maxDistance);
-    Map<Task, List<Resource>> taskSchedule = schedule.createSchedule();
+    Schedule schedule = new Schedule();
+    Map<Task, List<Resource>> taskSchedule = schedule.updateSchedule(mockTasks, maxDistance);
     assertTrue(taskSchedule.containsKey(mockTask1),
         "Created schedule should contain mockTask1");
     assertEquals(1, taskSchedule.get(mockTask1).size(),
@@ -119,25 +97,16 @@ public class ScheduleUnitTests {
     when(mockResourceType.countAvailableUnits(any())).thenReturn(1);
     when(mockResourceType.findAvailableResource(any())).thenReturn(mockResource1);
 
-    Schedule scheduleForInvalidTask = new Schedule(testScheduleId, mockTasks, maxDistance);
+    Schedule scheduleForInvalidTask = new Schedule();
     assertThrows(IllegalArgumentException.class,
-        () -> scheduleForInvalidTask.unscheduleTask(mock(Task.class)),
-        "unscheduleTask method should throw exception when unscheduling invalid task");
+        () -> scheduleForInvalidTask.unscheduleTask(null),
+        "unscheduleTask method should throw exception when unscheduling null task");
 
-    Schedule scheduleForValidTask = new Schedule(testScheduleId, mockTasks, maxDistance);
-    scheduleForValidTask.createSchedule();
+    Schedule scheduleForValidTask = new Schedule();
+    scheduleForValidTask.updateSchedule(mockTasks, maxDistance);
     assertDoesNotThrow(() -> scheduleForValidTask.unscheduleTask(mockTask1),
         "unscheduleTask method should not throw exception when unscheduling valid task");
     verify(mockResource1, times(1)).release();
   }
 
-  /**
-   * Test for getScheduleId method in Schedule class.
-   */
-  @Test
-  void getScheduleIdTest() {
-    Schedule testSchedule = new Schedule(testScheduleId, mockTasks, maxDistance);
-    assertEquals(testScheduleId, testSchedule.getScheduleId(),
-        "getScheduleId should return the correct schedule ID.");
-  }
 }


### PR DESCRIPTION
This PR:

- Modified MyFileDatabase to store one Schedule instance (a master schedule that contains all schedules)
- Modified the Schedule class to not store a queue of tasks and maxDistance; instead take them as parameters in the updateSchedule method (RouteController passes them)
- Modified the scheduling logic to pass tasks that are already scheduled and tasks that have empty resources list
- Added overridden methods to the Task class so that Task objects are compared by taskIds
- Made Schedule and TaskComparator classes to implement Serializable
- Combined retrieveSchedules and retrieveSchedule API endpoints into just one (retrieveSchedule)
- Updated other API endpoints as well as unit tests
- Passes checkstyle and PMD