### PR TITLE
Refined schedule APIs to return cleaner JSON

### DIFF
--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/Schedule.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/Schedule.java
@@ -43,10 +43,11 @@ public class Schedule implements Serializable {
       throw new IllegalArgumentException("Maximum distance cannot be negative.");
     }
 
-    // Sort tasks by priority
-    tasks.sort(new TaskComparator());
+    // Create a copy of tasks and sort by priority
+    List<Task> copiedTasks = new ArrayList<>(tasks);
+    copiedTasks.sort(new TaskComparator());
 
-    for (Task task : tasks) {
+    for (Task task : copiedTasks) {
       // Skip tasks that are already scheduled
       if (taskSchedule.containsKey(task)) {
         continue;

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/Task.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/Task.java
@@ -172,29 +172,6 @@ public class Task implements Serializable {
   }
 
   /**
-   * Returns a string representation of the task, including its id, location,
-   * start and end time, priority and the resources needed.
-   *
-   * @return A string representing the task.
-   */
-  public String toString() {
-    StringBuilder result = new StringBuilder();
-    result.append("Task ID: ").append(taskId).append("; ")
-            .append("Location: ").append(location.getCoordinates()).append("; ")
-            .append("Start: ").append(startTime.toString()).append("; ")
-            .append("End: ").append(endTime.toString()).append("; ")
-            .append("Priority: ").append(String.valueOf(priority)).append("\n")
-            .append("Resources Needed: \n");
-    for (Map.Entry<ResourceType, Integer> entry : resourceList.entrySet()) {
-      ResourceType key = entry.getKey();
-      Integer value = entry.getValue();
-      result.append(String.valueOf(value)).append(" of the following resource type is needed: \n")
-              .append(key.toString()).append("\n");
-    }
-    return result.toString();
-  }
-
-  /**
    * Updates the location of the task.
    *
    * @param latitude  the new latitude of the task's location


### PR DESCRIPTION
This PR:

- Refined the schedule APIs to return a better structured JSON response 
- Made minor modification in the updateSchedule method such that it does not modify the original tasks list
- Removed toString method in Task class as no longer needed
- Passes checkstyle and PMD