### PR TITLE
Fix addResourceType and deleteResourceType

### DIFF
--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/Location.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/Location.java
@@ -2,6 +2,7 @@ package dev.coms4156.project.livesched;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Represents a location using a geographic coordinate system.
@@ -70,6 +71,24 @@ public class Location implements Serializable {
 
   public double getLongitude() {
     return longitude;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    Location location = (Location) obj;
+    return Double.compare(location.latitude, latitude) == 0 &&
+        Double.compare(location.longitude, longitude) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(latitude, longitude);
   }
 
 }

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/Location.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/Location.java
@@ -82,8 +82,8 @@ public class Location implements Serializable {
       return false;
     }
     Location location = (Location) obj;
-    return Double.compare(location.latitude, latitude) == 0 &&
-        Double.compare(location.longitude, longitude) == 0;
+    return Double.compare(location.latitude, latitude) == 0
+        && Double.compare(location.longitude, longitude) == 0;
   }
 
   @Override

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/MyFileDatabase.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/MyFileDatabase.java
@@ -312,9 +312,18 @@ public class MyFileDatabase {
    * Adds a resource type to the database.
    *
    */
-  public void addResourceType(ResourceType resourceType) {
-
-    this.allResourceTypes.add(resourceType);
+  public void addResourceType(ResourceType newResourceType) {
+    for (ResourceType existingResource : this.allResourceTypes) {
+      if (existingResource.equals(newResourceType)) {
+        int newUnits = newResourceType.getTotalUnits();
+        for (int resource = 0; resource < newUnits; resource++) {
+          existingResource.addResource();
+        }
+        return;
+      }
+    }
+    // If no match is found, add the new resource type
+    this.allResourceTypes.add(newResourceType);
   }
 
   /**

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/ResourceType.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/ResourceType.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a specific type or group of resources.
@@ -118,15 +119,6 @@ public class ResourceType implements Serializable {
    * @return A string representing the resource type.
    */
   public String toString() {
-    //    StringBuilder result = new StringBuilder();
-    //    result.append("Resource Type: ").append(typeName).append("; ")
-    //            .append("Location: ").append(location.getCoordinates()).append("\n")
-    //            .append("Available Resources: \n");
-    //    for (Map.Entry<String, Resource> entry : resources.entrySet()) {
-    //      Resource value = entry.getValue();
-    //      result.append(value.toString());
-    //    }
-    //    return result.toString();
     return typeName;
   }
 
@@ -140,4 +132,22 @@ public class ResourceType implements Serializable {
   public void updateLocation(double latitude, double longitude) {
     this.location = new Location(latitude, longitude);
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    ResourceType that = (ResourceType) obj;
+    return typeName.equals(that.typeName) && location.equals(that.location);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(typeName, location);
+  }
+
 }

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
@@ -394,7 +394,7 @@ public class RouteController {
         if (resourceType.getTypeName().equals(typeName)) {
           for (Task task : tasks) {
             if (task.getResources().containsKey(resourceType)) {
-              return new ResponseEntity<>("Cannot delete a resourceType currently in need",
+              return new ResponseEntity<>("Cannot delete a resourceType currently in use",
                   HttpStatus.BAD_REQUEST);
             }
           }

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/RouteController.java
@@ -394,7 +394,7 @@ public class RouteController {
         if (resourceType.getTypeName().equals(typeName)) {
           for (Task task : tasks) {
             if (task.getResources().containsKey(resourceType)) {
-              return new ResponseEntity<>("Cannot delete a resourceType currently in use",
+              return new ResponseEntity<>("Cannot delete a resourceType currently in need",
                   HttpStatus.BAD_REQUEST);
             }
           }

--- a/LiveSched/src/main/java/dev/coms4156/project/livesched/Task.java
+++ b/LiveSched/src/main/java/dev/coms4156/project/livesched/Task.java
@@ -151,20 +151,12 @@ public class Task implements Serializable {
       throw new IllegalArgumentException("Quantity cannot be negative.");
     }
 
-    // Find an existing ResourceType with the same typeName
-    ResourceType existingType = null;
-    for (ResourceType type : resourceList.keySet()) {
-      if (type.getTypeName().equals(resourceType.getTypeName())) {
-        existingType = type;
-        break;
-      }
-    }
-
-    if (existingType != null) {
+    // Check if the resourceType already exists
+    if (resourceList.containsKey(resourceType)) {
       if (quantity == 0) {
-        resourceList.remove(existingType); // Remove existing ResourceType from the list
+        resourceList.remove(resourceType); // Remove existing ResourceType from the list
       } else {
-        resourceList.replace(existingType, quantity); // Update quantity of existing ResourceType
+        resourceList.replace(resourceType, quantity); // Update quantity of existing ResourceType
       }
     } else {
       resourceList.put(resourceType, quantity); // Add new ResourceType and its quantity


### PR DESCRIPTION
This PR:

- Added overridden equals and hashCode methods to both Location and ResourceType classes such that Location instances with the same coordinates are considered equal and ResourceType instances with the same typeName and location are considered equal 
- Modified the addResourceType method in MyFileDatabase to check if there is an existing resourceType in the list and update it if found; if else, add the new resourceType to the list (This resolves the issue of having a new 'Nurse' entry in the list when there already exists a 'Nurse' entry with the same location -> now, in this case, there is just one entry and the number of total units gets updated)
- Resolved the issue of a resourceType being deleted when it is needed by at least one task
- Simplified the updateResource method in the Task class with the new overridden methods